### PR TITLE
mysql image compatible with platform linux/arm64/v8

### DIFF
--- a/apps/katib/upstream/components/mysql/mysql.yaml
+++ b/apps/katib/upstream/components/mysql/mysql.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: katib-mysql
-          image: mysql:8.0.26
+          image: mysql/mysql-server:8.0.26
           args:
             - --datadir
             - /var/lib/mysql/datadir


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
